### PR TITLE
Router: add a liquidity endpoint (draft)

### DIFF
--- a/bin/autobahn-router/src/edge_updater.rs
+++ b/bin/autobahn-router/src/edge_updater.rs
@@ -29,28 +29,6 @@ pub struct Dex {
 }
 
 impl Dex {
-    pub fn _desc(&self) -> String {
-        match &self.subscription_mode {
-            DexSubscriptionMode::Disabled => {
-                format!("Dex {} mode=Disabled", self.name)
-            }
-            DexSubscriptionMode::Accounts(subscribed_pks) => {
-                format!("Dex {} mode=gMa #pks={}", self.name, subscribed_pks.len())
-            }
-            DexSubscriptionMode::Programs(subscribed_prgs) => format!(
-                "Dex {} mode=gPa program_ids={:?}",
-                self.name, subscribed_prgs
-            ),
-            DexSubscriptionMode::Mixed(m) => format!(
-                "Dex {} mode=mix #pks={} program_ids={:?}, tokens_for_owners={:?}",
-                self.name,
-                m.accounts.len(),
-                m.programs,
-                m.token_accounts_for_owner
-            ),
-        }
-    }
-
     pub fn edges(&self) -> Vec<Arc<Edge>> {
         let edges: Vec<Arc<Edge>> = self
             .edges_per_pk

--- a/bin/autobahn-router/src/liquidity/liquidity_computer.rs
+++ b/bin/autobahn-router/src/liquidity/liquidity_computer.rs
@@ -1,0 +1,57 @@
+use crate::edge::Edge;
+use router_lib::dex::AccountProviderView;
+use std::sync::Arc;
+
+pub fn compute_liquidity(
+    edge: &Arc<Edge>,
+    chain_data: &AccountProviderView,
+) -> anyhow::Result<u64> {
+    let loaded = edge.prepare(&chain_data)?;
+
+    let first_in_amount = edge
+        .state
+        .read()
+        .unwrap()
+        .cached_prices
+        .first()
+        .map(|x| x.0);
+    let Some(first_in_amount) = first_in_amount else {
+        anyhow::bail!("Too early to compute liquidity");
+    };
+
+    let mut iter_counter = 0;
+    let mut has_failed = false;
+    let mut last_successful_in_amount = first_in_amount;
+    let mut next_in_amount = first_in_amount;
+    let mut last_successful_out_amount = 0;
+    let acceptable_price_impact = 0.3;
+
+    loop {
+        if next_in_amount == 0 || iter_counter > 50 {
+            break;
+        }
+        iter_counter = iter_counter + 1;
+
+        let quote = edge.quote(&loaded, &chain_data, next_in_amount);
+        let expected_output = (2.0 - acceptable_price_impact) * last_successful_out_amount as f64;
+
+        let out_amount = quote.map(|x| x.out_amount).unwrap_or(0);
+
+        if (out_amount as f64) < expected_output {
+            if has_failed {
+                break;
+            }
+            has_failed = true;
+            next_in_amount = next_in_amount
+                .saturating_add(last_successful_in_amount)
+                .saturating_div(2);
+            continue;
+        };
+
+        last_successful_in_amount = next_in_amount;
+        last_successful_out_amount = out_amount;
+        next_in_amount = next_in_amount.saturating_mul(2);
+    }
+
+    Ok(last_successful_out_amount)
+}

--- a/bin/autobahn-router/src/liquidity/liquidity_provider.rs
+++ b/bin/autobahn-router/src/liquidity/liquidity_provider.rs
@@ -1,0 +1,66 @@
+use crate::token_cache::TokenCache;
+use ordered_float::{FloatCore, Pow};
+use router_lib::price_feeds::price_cache::PriceCache;
+use solana_program::pubkey::Pubkey;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+pub struct Liquidity {
+    pub liquidity_by_pool: HashMap<Pubkey, u64>,
+}
+
+pub struct LiquidityProvider {
+    liquidity_by_mint: HashMap<Pubkey, Liquidity>,
+    token_cache: TokenCache,
+    price_cache: PriceCache,
+}
+
+pub type LiquidityProviderArcRw = Arc<RwLock<LiquidityProvider>>;
+
+impl LiquidityProvider {
+    pub fn new(token_cache: TokenCache, price_cache: PriceCache) -> LiquidityProvider {
+        LiquidityProvider {
+            liquidity_by_mint: Default::default(),
+            token_cache,
+            price_cache,
+        }
+    }
+
+    pub fn set_liquidity(&mut self, mint: Pubkey, pool: Pubkey, liquidity: u64) {
+        if let Some(cache) = self.liquidity_by_mint.get_mut(&mint) {
+            cache.liquidity_by_pool.insert(pool, liquidity);
+        } else {
+            self.liquidity_by_mint.insert(
+                mint,
+                Liquidity {
+                    liquidity_by_pool: HashMap::from([(pool, liquidity)]),
+                },
+            );
+        }
+    }
+
+    pub fn get_total_liquidity_native(&self, mint: Pubkey) -> u64 {
+        if let Some(cache) = self.liquidity_by_mint.get(&mint) {
+            let mut sum = 0u64;
+            for amount in cache.liquidity_by_pool.iter().map(|x| x.1) {
+                sum = sum.saturating_add(*amount);
+            }
+            sum
+        } else {
+            0
+        }
+    }
+
+    pub fn get_total_liquidity_in_dollars(&self, mint: Pubkey) -> anyhow::Result<f64> {
+        let liquidity_native = self.get_total_liquidity_native(mint);
+        let price = self
+            .price_cache
+            .price_ui(mint)
+            .ok_or(anyhow::format_err!("no price"))?;
+        let decimal = self.token_cache.token(mint).map(|x| x.decimals)?;
+
+        let liquidity_dollars = (liquidity_native as f64 / 10.0.pow(decimal as f64)) * price;
+
+        Ok(liquidity_dollars)
+    }
+}

--- a/bin/autobahn-router/src/liquidity/liquidity_updater.rs
+++ b/bin/autobahn-router/src/liquidity/liquidity_updater.rs
@@ -1,0 +1,64 @@
+use crate::debug_tools;
+use crate::edge::Edge;
+use crate::liquidity::liquidity_computer::compute_liquidity;
+use crate::liquidity::liquidity_provider::LiquidityProviderArcRw;
+use crate::util::tokio_spawn;
+use itertools::Itertools;
+use router_lib::dex::AccountProviderView;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+use tracing::{debug, info};
+
+pub fn spawn_liquidity_updater_job(
+    provider: LiquidityProviderArcRw,
+    edges: Vec<Arc<Edge>>,
+    chain_data: AccountProviderView,
+    mut exit: broadcast::Receiver<()>,
+) -> JoinHandle<()> {
+    let job = tokio_spawn("liquidity_updater", async move {
+        let mut refresh_all_interval = tokio::time::interval(Duration::from_secs(30));
+        refresh_all_interval.tick().await;
+
+        loop {
+            tokio::select! {
+                _ = exit.recv() => {
+                    info!("shutting down liquidity_updater task");
+                    break;
+                }
+                _ = refresh_all_interval.tick() => {
+                    refresh_liquidity(&provider, &edges, &chain_data);
+                }
+            }
+        }
+    });
+
+    job
+}
+
+fn refresh_liquidity(
+    provider: &LiquidityProviderArcRw,
+    edges: &Vec<Arc<Edge>>,
+    account_provider: &AccountProviderView,
+) {
+    for edge in edges {
+        let liquidity = compute_liquidity(&edge, &account_provider);
+        if let Ok(liquidity) = liquidity {
+            provider
+                .write()
+                .unwrap()
+                .set_liquidity(edge.output_mint, edge.id.key(), liquidity);
+        } else {
+            debug!("Could not compute liquidity for {}", edge.id.desc())
+        }
+    }
+
+    for mint in edges.iter().map(|x| x.output_mint).unique() {
+        debug!(
+            "Liquidity for {} -> {}",
+            debug_tools::name(&mint),
+            provider.read().unwrap().get_total_liquidity_native(mint)
+        )
+    }
+}

--- a/bin/autobahn-router/src/liquidity/mod.rs
+++ b/bin/autobahn-router/src/liquidity/mod.rs
@@ -1,0 +1,7 @@
+mod liquidity_computer;
+mod liquidity_provider;
+mod liquidity_updater;
+
+pub use liquidity_provider::LiquidityProvider;
+pub use liquidity_provider::LiquidityProviderArcRw;
+pub use liquidity_updater::spawn_liquidity_updater_job;

--- a/lib/dex-raydium-cp/src/edge.rs
+++ b/lib/dex-raydium-cp/src/edge.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-use std::panic;
 use anchor_lang::Id;
 use anchor_spl::token::Token;
 use anchor_spl::token_2022::spl_token_2022::extension::transfer_fee::TransferFeeConfig;
@@ -14,6 +12,8 @@ use solana_program::clock::Clock;
 use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::Sysvar;
 use solana_sdk::account::ReadableAccount;
+use std::any::Any;
+use std::panic;
 
 use router_lib::dex::{DexEdge, DexEdgeIdentifier};
 
@@ -189,8 +189,7 @@ pub fn swap_base_output(
     output_mint: &Option<TransferFeeConfig>,
     amount_out: u64,
 ) -> anyhow::Result<(u64, u64, u64)> {
-    let res = panic::catch_unwind(||
-    {
+    let res = panic::catch_unwind(|| {
         let pool_state = pool;
         let block_timestamp = pool_state.open_time + 1; // TODO FAS his is suppose to be the clock
         if !pool_state.get_status_by_bit(PoolStatusBitIndex::Swap)
@@ -269,7 +268,6 @@ pub fn swap_base_output(
     } else {
         anyhow::bail!("Something went wrong in raydium cp")
     }
-
 }
 
 pub fn get_transfer_fee(

--- a/lib/router-lib/src/model/liquidity_request.rs
+++ b/lib/router-lib/src/model/liquidity_request.rs
@@ -1,0 +1,8 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[allow(dead_code)]
+#[serde(rename_all = "camelCase")]
+pub struct LiquidityRequest {
+    pub mints: String,
+}

--- a/lib/router-lib/src/model/liquidity_response.rs
+++ b/lib/router-lib/src/model/liquidity_response.rs
@@ -1,0 +1,9 @@
+use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[serde_with::serde_as]
+pub struct LiquidityResponse {
+    pub liquidity: HashMap<String, f64>,
+}

--- a/lib/router-lib/src/model/mod.rs
+++ b/lib/router-lib/src/model/mod.rs
@@ -1,3 +1,5 @@
+pub mod liquidity_request;
+pub mod liquidity_response;
 pub mod quote_request;
 pub mod quote_response;
 pub mod swap_request;


### PR DESCRIPTION
Fetch total liquidity (in US $) of a token reachable through autobahn

This first version compute an estimation of reachable liquidity using existing quoting API and an heuristic (if output stop to grow with input, then it means we reached max available quantity for a pool)
It could be improved by using dex specific code. 

Query example (for SOL, USDC, MNGO & WIF):
```
http://127.0.0.1:8888/liquidity?mints=So11111111111111111111111111111111111111112,EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v,MangoCzJ36AjZyKwVj3VnYU4GTonjfVEnJmvvWaxLac,EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm
``` 

Result:
```
{
  "liquidity": {
    "EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm": 1651150.4687013852,
    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v": 15627441.321525,
    "MangoCzJ36AjZyKwVj3VnYU4GTonjfVEnJmvvWaxLac": 173.31381035204276,
    "So11111111111111111111111111111111111111112": 44315126.80003761
  }
}
```